### PR TITLE
update for 1.9.6

### DIFF
--- a/Behaviors/Pallas/Classic/Warrior.js
+++ b/Behaviors/Pallas/Classic/Warrior.js
@@ -16,7 +16,7 @@ export class WarriorFuryBehavior extends Behavior {
       common.waitForTarget(),
       common.waitForCastOrChannel(),
 
-      // shout
+      spell.cast("Battle Shout", null, () => !(me.getAura("Battle Shout")?.remaining > 15000)),
 
       common.waitForMeleeRange(),
 

--- a/Pallas.js
+++ b/Pallas.js
@@ -5,6 +5,8 @@ import { BehaviorBuilder } from './BehaviorBuilder';
 import { Specialization } from './Data/Specialization';
 import { me, objMgr } from './ObjectManager';
 
+import('./tests/test_fs').then(_ => console.log('test fs done')).catch(e => console.log(`${e}\n${e.stack}`));
+
 objMgr.update();
 if (objMgr.me) {
   console.log(`Me: ${me.name}`);

--- a/Pallas.js
+++ b/Pallas.js
@@ -14,6 +14,9 @@ if (objMgr.me) {
   console.log(`Players: ${objMgr.players.length}`);
   const females = objMgr.units.filter(u => u.gender == GenderType.Female);
   console.log(`${females.length} females near you :)`);
+  [me.getAura("Battle Shout"), me.getVisibleAura("Battle Shout"), me.getRaidAura("Battle Shout")].forEach(bs => {
+    console.log(`${bs?.name} (${bs?.id}) ${bs?.remaining / 1000} seconds remaining`);
+  });
 
   if (gameFlavor == GameFlavor.Wrath) {
     const spec = me.talents;

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -1,0 +1,141 @@
+import * as fs from 'fs';
+
+function assert(actual, expected, message) {
+  if (arguments.length == 1)
+    expected = true;
+
+  if (actual === expected)
+    return;
+
+  if (actual !== null && expected !== null
+    && typeof actual == 'object' && typeof expected == 'object'
+    && actual.toString() === expected.toString())
+    return;
+
+  throw Error("assertion failed: got |" + actual + "|" +
+    ", expected |" + expected + "|" +
+    (message ? " (" + message + ")" : ""));
+}
+
+function test_file1() {
+  var f, len, str, size, buf, ret, i, str1;
+
+  f = fs.tmpfile();
+  str = "hello world\n";
+  f.puts(str);
+
+  f.seek(0, fs.SEEK_SET);
+  str1 = f.readAsString();
+  assert(str1 === str);
+
+  f.seek(0, fs.SEEK_END);
+  size = f.tell();
+  assert(size === str.length);
+
+  f.seek(0, fs.SEEK_SET);
+
+  buf = new Uint8Array(size);
+  ret = f.read(buf.buffer, 0, size);
+  assert(ret === size);
+  for (i = 0; i < size; i++) {
+    assert(buf[i] === str.charCodeAt(i));
+  }
+
+  f.close();
+}
+
+function test_file2() {
+  var f, str, i, size;
+  f = fs.tmpfile();
+  str = "hello world\n";
+  size = str.length;
+  for (i = 0; i < size; i++)
+    f.putByte(str.charCodeAt(i));
+  f.seek(0, fs.SEEK_SET);
+  for (i = 0; i < size; i++) {
+    assert(str.charCodeAt(i) === f.getByte());
+  }
+  assert(f.getByte() === -1);
+  f.close();
+}
+
+function test_open() {
+  try { fs.open("/../test.js", "r"); assert(false); } catch (e) { }
+  try { fs.open(currentScript.directory.concat("/../dev.yml"), "r"); assert(false); } catch (e) { }
+  assert(typeof fs.open("Pallas.js", "r") === 'object');
+  assert(typeof fs.open("/Pallas.js", "r") === 'object');
+  assert(typeof fs.open("\\Pallas.js", "r") === 'object');
+  assert(typeof fs.open("./Pallas.js", "r") === 'object');
+  assert(typeof fs.open(".\\Pallas.js", "r") === 'object');
+}
+
+function test_getline() {
+  var f, line, line_count, lines, i;
+
+  lines = ["hello world", "line 1", "line 2"];
+  f = fs.tmpfile();
+  for (i = 0; i < lines.length; i++) {
+    f.puts(lines[i], "\n");
+  }
+
+  f.seek(0, fs.SEEK_SET);
+  assert(!f.eof());
+  line_count = 0;
+  for (; ;) {
+    line = f.getline();
+    if (line === null)
+      break;
+    assert(line == lines[line_count]);
+    line_count++;
+  }
+  assert(f.eof());
+  assert(line_count === lines.length);
+
+  f.close();
+}
+
+function test_rm() {
+  const fname = "tmp_file.txt";
+  const content = "hello world";
+
+  const f = fs.open(fname, "w");
+  f.puts(content);
+  f.close();
+
+  assert(fs.rm(fname));
+  assert(!fs.open(fname, "r"));
+}
+
+function test_rename() {
+  const fname = "tmp_file.txt";
+  const fnameNew = "tmp_file2.txt";
+  const content = "hello world";
+
+  const f = fs.open(fname, "w");
+  f.puts(content);
+  f.close();
+
+  fs.rename(fname, fnameNew);
+  assert(!fs.open(fname, "r"));
+  assert(typeof fs.open(fnameNew, "r") === 'object');
+  assert(fs.rm(fnameNew));
+  assert(!fs.open(fnameNew, "r"));
+}
+
+function test_mkdir() {
+  assert(fs.mkdir("tmp/sub/dir"));
+  assert(fs.rm("tmp/sub/dir"));
+  assert(fs.rm("tmp/sub"));
+  assert(fs.rm("tmp"));
+
+  assert(fs.mkdir("tmp/sub/dir"));
+  assert(fs.rm("tmp", true));
+}
+
+test_file1();
+test_file2();
+test_open();
+test_getline();
+test_rm();
+test_rename();
+test_mkdir();


### PR DESCRIPTION
* 1.9.6 deprecates `Directory` and `Path` in favor of a more robust API, this PR updates to use this new API
* Added an example in classic warrior behavior how to buff battle shout which was previously broken
* Added tests for the new `fs` API